### PR TITLE
Update to 22.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Forge
-RUN bash -c "wget -q -O- https://content.allinea.com/downloads/arm-forge-22.0.1-linux-aarch64.tar | tar x && arm-forge-*/textinstall.sh --accept-licence /opt/arm/forge/22.0.1"
+RUN bash -c "wget -q -O- https://content.allinea.com/downloads/arm-forge-22.0.1-linux-aarch64.tar | tar x && arm-forge-*/textinstall.sh --accept-licence /opt/arm/forge/22.0.1; rm -rf /tmp/*"
 
 # Compiler (and cleanup)
 RUN bash -c "wget -q -O- https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/22-0-1/arm-compiler-for-linux_22.0.1_Ubuntu-20.04_aarch64.tar | tar x && ./arm-compiler-for-linux*/*.sh --accept; rm -rf /tmp/*"
@@ -37,11 +37,6 @@ RUN bash -c "wget -q -O- https://developer.arm.com/-/media/Files/downloads/hpc/a
 # Setup modules
 RUN echo "/opt/arm/modulefiles" >> /usr/share/modules/init/.modulespath
 COPY modulefiles /opt/arm/modulefiles/
-
-# By rebuilding the image from scratch, and copying in the result
-# we save image size
-FROM arm64v8/ubuntu:20.04
-COPY --from=builder / /
 
 RUN useradd -ms /bin/bash user
 USER user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04 as builder
+FROM arm64v8/ubuntu:20.04 as builder
 
 USER root
 
@@ -29,16 +29,10 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # Forge
-RUN bash -c "wget -q -O- https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/19-1/Ubuntu16.04/arm-forge-19.0.3-Ubuntu-16.04-aarch64.tar | tar x && arm-forge-*-Ubuntu-16.04-aarch64/textinstall.sh --accept-licence /opt/arm/forge/19.0.3"
-
-# Performance Reports
-RUN bash -c "wget -q -O- https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/19-1/Ubuntu16.04/arm-reports-19.0.3-Ubuntu-16.04-aarch64.tar | tar x && ./arm-reports-*-Ubuntu-16.04-aarch64/textinstall.sh --accept-licence /opt/arm/perf-reports/19.0.3"
-
-# Instruction Emulator
-RUN bash -c "wget -q -O- https://armkeil.blob.core.windows.net/developer/Files/downloads/hpc/arm-instruction-emulator/18-4/ARM-Instruction-Emulator_18.4_AArch64_Ubuntu_16.04_aarch64.tar.gz | tar zx && ./ARM-Instruction-Emulator_18.4_AArch64_Ubuntu_16.04_aarch64/arm-instruction-emulator-18.4_Generic-AArch64_Ubuntu-16.04_aarch64-linux-deb.sh --accept"
+RUN bash -c "wget -q -O- https://content.allinea.com/downloads/arm-forge-22.0.1-linux-aarch64.tar | tar x && arm-forge-*/textinstall.sh --accept-licence /opt/arm/forge/22.0.1"
 
 # Compiler (and cleanup)
-RUN bash -c "wget -q -O- https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/19-1/Ubuntu16.04/Arm-Compiler-for-HPC_19.1_Ubuntu_16.04_aarch64.tar | tar x && ./ARM-Compiler-for-HPC*/*.sh --accept; rm -rf /tmp/*"
+RUN bash -c "wget -q -O- https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/22-0-1/arm-compiler-for-linux_22.0.1_Ubuntu-20.04_aarch64.tar | tar x && ./arm-compiler-for-linux*/*.sh --accept; rm -rf /tmp/*"
 
 # Setup modules
 RUN echo "/opt/arm/modulefiles" >> /usr/share/modules/init/.modulespath
@@ -46,7 +40,7 @@ COPY modulefiles /opt/arm/modulefiles/
 
 # By rebuilding the image from scratch, and copying in the result
 # we save image size
-FROM arm64v8/ubuntu:18.04
+FROM arm64v8/ubuntu:20.04
 COPY --from=builder / /
 
 RUN useradd -ms /bin/bash user

--- a/modulefiles/forge/19.0.3
+++ b/modulefiles/forge/19.0.3
@@ -1,8 +1,0 @@
-#%Module1.0#####################################################################
-proc ModulesHelp { } {
-        puts stderr "Sets the Environment for Arm Forge 19.0.3"
-}
-
-module-whatis   "Sets the environment for Arm Forge 19.0.3"
-prepend-path PATH /opt/arm/forge/19.0.3/bin
-

--- a/modulefiles/forge/22.0.1
+++ b/modulefiles/forge/22.0.1
@@ -1,0 +1,8 @@
+#%Module1.0#####################################################################
+proc ModulesHelp { } {
+        puts stderr "Sets the Environment for Arm Forge 22.0.1"
+}
+
+module-whatis   "Sets the environment for Arm Forge 22.0.1"
+prepend-path PATH /opt/arm/forge/22.0.1/bin
+

--- a/modulefiles/perf-reports/19.0.3
+++ b/modulefiles/perf-reports/19.0.3
@@ -1,8 +1,0 @@
-#%Module1.0#####################################################################
-proc ModulesHelp { } {
-        puts stderr "Sets the Environment for Arm Performance Reports 19.0.3"
-}
-
-module-whatis   "Sets the environment for Arm Performance Reports 19.0.3"
-prepend-path PATH /opt/arm/perf-reports/19.0.3/bin
-


### PR DESCRIPTION
* Updates which installers we use, and Forge modulefiles
* Removes ArmIE (no currently supported release)
* Tidies up the forge install, to prevent the need for a docker image copy